### PR TITLE
Fix misnamed init param in publish.yml

### DIFF
--- a/.rwx/publish.yml
+++ b/.rwx/publish.yml
@@ -14,7 +14,7 @@ tasks:
     with:
       repository: https://github.com/rwx-cloud/vscode-extension.git
       github-access-token: ${{ github['rwx-cloud'].token }}
-      ref: ${{ init.ref }}
+      ref: ${{ init.commit-sha }}
 
   - key: tool-versions
     use: [code]


### PR DESCRIPTION
Earlier attempt: https://cloud.rwx.com/mint/rwx/runs/3342901b34a6409c9fbf8b9fb428bba4